### PR TITLE
feat - toggle menu when is dropped down

### DIFF
--- a/src/app/@core/components/shared/navbar/navbar.component.html
+++ b/src/app/@core/components/shared/navbar/navbar.component.html
@@ -2,29 +2,35 @@
 <nav class="navbar fixed-top navbar-expand-lg navbar-dark fixed-top" [ngStyle]="{'background-color': backgroundColor}">
   <div class="container">
     <a class="navbar-brand" [routerLink]="mainItem.link">{{ mainItem.title }}</a>
-    <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
+    <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse"
+            data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false"
+            aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
     <div class="collapse navbar-collapse" id="navbarResponsive" *ngIf="menuItems">
       <ul class="navbar-nav ml-auto">
-        <li class="nav-item" [ngClass]="{'dropdown': item.link == '*'}" *ngFor="let item of menuItems" title="{{item.title | translate}}">
+        <li class="nav-item" [ngClass]="{'dropdown': item.link == '*'}" *ngFor="let item of menuItems"
+            title="{{item.title | translate}}">
           <!-- Menu item without submenus -->
-          <a class="nav-link" *ngIf="item.link != '*' && item.active" [routerLink]="item.link" routerLinkActive="active">{{item.title | translate}}</a>
+          <a class="nav-link" data-toggle="collapse" data-target="#navbarResponsive"
+             *ngIf="item.link != '*' && item.active"
+             [routerLink]="item.link" routerLinkActive="active">{{item.title | translate}}</a>
           <!--Menu item with submenus-->
-          <a class="nav-link dropdown-toggle" *ngIf="item.link == '*'" href="#" id="navbarDropdownPortfolio" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-              {{ item.title | translate }}
-            </a>
+          <a class="nav-link dropdown-toggle" *ngIf="item.link == '*'" href="#" id="navbarDropdownPortfolio"
+             data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            {{ item.title | translate }}
+          </a>
           <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdownPortfolio">
             <div *ngFor="let sub of item.submenus">
-              <a class="dropdown-item" [routerLink]="sub.link" 
-                                routerLinkActive="active" title="{{item.subtitle | translate}}" >{{ sub.title | translate }} </a>
+              <a class="dropdown-item" [routerLink]="sub.link"
+                 routerLinkActive="active" title="{{item.subtitle | translate}}">{{ sub.title | translate }} </a>
             </div>
-            
+
           </div>
         </li>
         <li *ngIf="loginUserAdmin">
-          <a class="nav-link" [routerLink]="['/admin/dashboard']" 
-                                routerLinkActive="active" >{{ 'menus.admin' | translate}}</a>
+          <a class="nav-link" [routerLink]="['/admin/dashboard']"
+             routerLinkActive="active">{{ 'menus.admin' | translate}}</a>
         </li>
         <li *ngIf="loginUserAdmin">
           <a class="nav-link" (click)="logout()">{{ 'menus.closeSession' | translate}}</a>


### PR DESCRIPTION
Un pequeño aporte para que cuando estés en el móvil y el menú esté abierto, éste haga el Toggle para cerrar el menú.

Importante: Esto no está implementado para los submenús y posible bug, si el submenú se acciona con un click, entonces cerraría el menú completo por el toggle implementado. Una sugerencia es crear una condición: isSubmenú y activarlo de forma dinámica desde la clase del componente para evitar que se cierre.

Si quieres puedo contribuir para arreglarlo y hacerlo funcional, solo necesitas poner un submenú nested de ejemplo en el array de menuItems. 